### PR TITLE
add function renaming

### DIFF
--- a/defopt.py
+++ b/defopt.py
@@ -131,6 +131,9 @@ def _create_parser(funcs, **kwargs):
     else:
         subparsers = parser.add_subparsers()
         for func in funcs:
+            if isinstance(funcs, dict):
+                name, func = func, funcs[func]
+                func.__name__ = name.replace("_", "-")
             subparser = subparsers.add_parser(
                 func.__name__.replace('_', '-'),
                 formatter_class=formatter_class,

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -52,6 +52,23 @@ The command line usage will indicate this. ::
 
 Underscores in function names are replaced by hyphens.
 
+Friendlier names can be provided by calling `defopt.run` with a dict of
+`{"func":function_with_long_name}` pairs. The keys replace the corresponding
+function names at the command line. As when called with a list, underscores in
+keys are replaced by hyphens.
+
+.. code-block:: python
+
+   defopt.run({"friendly_func":function_with_a_long_name, "func2":another_function})
+
+Command line usage will use the new names ::
+
+    usage: test.py [-h] {friendly-func,func2} ...
+
+    positional arguments:
+      {friendly-func,func2}
+
+
 Standard types
 --------------
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -53,6 +53,12 @@ class TestDefopt(unittest.TestCase):
         self.assertEqual(
             defopt.run([sub, sub_with_dash], strict_kwonly=False,
                        argv=['sub-with-dash', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub1":sub, "sub_2":sub_with_dash}, strict_kwonly=False,
+                       argv=['sub1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub1":sub, "sub_2":sub_with_dash}, strict_kwonly=False,
+                       argv=['sub-2', '--baz', '1']), 1)
 
     def test_var_positional(self):
         def main(*foo):


### PR DESCRIPTION
closes #63 

In addition to the existing ways of calling defopt.run, we can now pass a dict
of {"name":function} key/value pairs to use name in
lieu of `function.__name__` at the command line

This is useful if you like to use long descriptive function names in your python
code, but be able to call them with shorter, more friendly names at the command line