### PR TITLE
Add implicit_false option

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,7 @@ next
 ----
 * Boolean flags are now implemented using a variant of
   ``argparse.BooleanOptionalAction``.
+* Added ``no_negated_flags``.
 
 6.0.2 (2020-12-08)
 ------------------

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -155,6 +155,10 @@ help text and the default are displayed next to the ``--name`` flag::
 Note that this does not apply to mandatory boolean parameters; these must be
 specified as one of ``1/t/true`` or ``0/f/false`` (case insensitive).
 
+If ``no_negated_flags=True`` is passed to `defopt.run`, no negated flags
+(``--no-name``) are generated for boolean arguments that have `False`
+as their default value.
+
 A runnable example is available at `examples/booleans.py`_.
 
 Lists

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -791,6 +791,15 @@ class TestHelp(unittest.TestCase):
         self.assert_in_help('(default: False)', foo, 'd')
         self.assert_not_in_help('(', foo, '')
 
+    def test_no_negated_flags(self):
+        def main(*, foo=False, bar=True):
+            """
+            :param bool foo: Foo
+            :param bool bar: Bar
+            """
+        self.assert_not_in_help('--no-foo', main, 'n')
+        self.assert_in_help('--no-bar', main, 'n')
+
     def test_keyword_only(self):
         def foo(*, bar):
             """:param int bar: baz"""
@@ -885,10 +894,10 @@ class TestHelp(unittest.TestCase):
         self.assertNotIn(s, self._get_help(funcs, flags))
 
     def _get_help(self, funcs, flags):
-        self.assertLessEqual({*flags}, {'d', 't'})
+        self.assertLessEqual({*flags}, {'d', 't', 'n'})
         parser = defopt._create_parser(
             funcs, show_defaults='d' in flags, show_types='t' in flags,
-            strict_kwonly=False)
+            no_negated_flags='n' in flags, strict_kwonly=False)
         return parser.format_help()
 
 


### PR DESCRIPTION
Thank you for very nice library.

Many command-line tools have a single flag to turn on a specified behvior and no flag to turn it off. This patch adds an optional argument `implicit_false` to `defopt.run`. If this argument is `True`, any non-positional boolean argument with `False` as a default, has no `--no-xxx` flag. This makes the command line interface simpler (user simply adds `--xxx` flat to set the value to `True` and skips it to set it to `False`).