### PR TITLE
Add recursive subcommands

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -11,6 +11,7 @@ next
   exception types.
 * Added `defopt.bind` to allow preprocessing arguments before performing the
   call.
+* Added the ability to use nested subcommands.
 
 6.1.0 (2021-02-25)
 ------------------

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -79,4 +79,12 @@ Docstring styles
     :undoc-members:
     :show-inheritance:
 
+Nested subcommands
+------------------
+
+.. automodule:: examples.nested
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. _examples: https://github.com/anntzer/defopt/tree/master/examples

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -79,6 +79,20 @@ Command line usage will use the new names ::
     positional arguments:
       {friendly_func,func2}
 
+Nested Subcommands
+------------------
+
+By using dictionaries, the subcommands can also be nested.
+
+.. code-block:: python
+
+    defopt.run({'func1': func1, 'sub': [func2, func3]})
+
+The nested subcommands are accessed e.g. by ``test.py sub func2``.  The
+subcommands can be nested to an arbitrary level by using nested dictionaries.
+
+A runnable example is available at `examples/nested.py`_.
+
 Standard types
 --------------
 
@@ -376,3 +390,4 @@ script importable independently of `defopt`.
 .. _examples/short.py: https://github.com/anntzer/defopt/blob/master/examples/short.py
 .. _examples/starargs.py: https://github.com/anntzer/defopt/blob/master/examples/starargs.py
 .. _examples/styles.py: https://github.com/anntzer/defopt/blob/master/examples/styles.py
+.. _examples/nested.py https://github.com/anntzer/defopt/blob/master/examples/nested.py

--- a/examples/nested.py
+++ b/examples/nested.py
@@ -1,0 +1,47 @@
+"""
+Example showing nested parsers in defopt.
+
+Code usage::
+
+    >>> main(1.5)
+    >>> sub1(2.0)
+    >>> sub2(2.5)
+
+Command line usage::
+
+    $ python nested.py main 1.5
+    $ python nested.py sub sub1 2.0
+    $ python nested.py sub sub2 2.5
+"""
+import defopt
+
+
+def main(number):
+    """
+    Example main function.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+def sub1(number):
+    """
+    Example sub command.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+def sub2(number):
+    """
+    Example sub command.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+if __name__ == '__main__':
+    defopt.run({'main': main, 'sub': [sub1, sub2]})

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -68,6 +68,133 @@ class TestDefopt(unittest.TestCase):
             defopt.run({"sub1": sub, "sub_2": sub_with_dash},
                        argv=['sub_2', '--baz', '1']), 1)
 
+    def test_nested_lists_invalid(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub1, [subsub1, subsub2]], argv=['sub1', '1.2'])
+
+    def test_nested_subcommands1(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-1', 'sub1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands2(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands3(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands_deep(self):
+        def sub(*bar):
+            """:type bar: float"""
+            return bar
+        self.assertEqual(
+            defopt.run({'a': {'b': {'c': {'d': {'e': sub}}}}},
+                       argv=['a', 'b', 'c', 'd', 'e', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({'a': {'b': {'c': {'d': {'e': [sub]}}}}},
+                       argv=['a', 'b', 'c', 'd', 'e', 'sub', '1.2']), (1.2,))
+
+    def test_nested_subcommands_mixed_invalid1(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub1', '1.2'])
+        with self.assertRaises(ValueError):
+                defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub2', 'subsub1', '--baz', '1'])
+        with self.assertRaises(ValueError):
+                defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub2', 'subsub2', '1.1'])
+
+    def test_nested_subcommands_mixed_invalid2(self):
+        def sub(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub_with_dash(*, baz=None): 
+            """:type baz: int"""
+            return baz
+        def subsub(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['sub', '1.2'])
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['subsub1', '--baz', '1'])
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['subsub2', '1.5'])
+
     def test_var_positional(self):
         for doc in [
                 ":type foo: int", r":type \*foo: int", ":param int foo: doc"]:


### PR DESCRIPTION
Here is an initial take on using recursion for nested subcommands.  I've added tests but I have not well tested it in a "real" application yet.

The docs (help message) as briefly discussed in #89 is not implemented at this point but I do like the idea of adding a `__doc__` or similar method to add help at the "higher level" subcommands.

This implementation also requires the subcommands to be mutable mappings so that the key can be used as the subcommand name.  I'm not sure where the subcommand name would come from if nested lists were used.  Perhaps a "magic" function with `__doc__` in the name could be used for that too, if it is desired to support it.

Closes #89