### PR TITLE
Add noxfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ htmlcov/
 oprofile_data/
 .coverage
 .gdb_history
+.venv/
+.coverage*
+.python-version
+.vscode/
+.nox/

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
+sphinx
 sphinx-autodoc-typehints

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import nox
+from nox import Session, session
+
+python_versions = ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+nox.options.sessions = ['tests', 'docs', 'style']
+nox.options.reuse_existing_virtualenvs = True
+
+
+@session(python=python_versions)
+@nox.parametrize('old', [False, True])
+def tests(session: Session, old: bool) -> None:
+    """Run the tests."""
+    args = session.posargs or ['--buffer']
+
+    session.install('--upgrade', 'pip', 'setuptools', 'wheel', 'coverage')
+    session.install('-e', '.')
+
+    if old:
+        # Oldest supported versions
+        session.install('docutils==0.12', 'sphinxcontrib-napoleon==0.7.0')
+        if session.python in ['3.5', '3.6', '3.7']:
+            session.install(
+                'typing_extensions==3.7.4', 'typing_inspect==0.5.0'
+            )
+        coverage_file = f'.coverage.{session.python}.oldest'
+    else:
+        coverage_file = f'.coverage.{session.python}'
+
+    try:
+        session.run(
+            'coverage',
+            'run',
+            '--module',
+            'unittest',
+            *args,
+            env={'COVERAGE_FILE': coverage_file},
+        )
+    finally:
+        if session.interactive:
+            session.notify('coverage', posargs=[])
+
+
+@session
+def coverage(session: Session) -> None:
+    """Produce the coverage report."""
+    args = session.posargs or ['report', '--show-missing']
+
+    session.install('coverage')
+
+    if not session.posargs and any(Path().glob('.coverage.*')):
+        session.run('coverage', 'combine')
+
+    session.run('coverage', *args)
+
+
+@session
+def docs(session: Session) -> None:
+    """Produce the coverage report."""
+    args = session.posargs or ['-b', 'html', 'doc/source', 'doc/build']
+
+    session.install('-r', 'doc/requirements.txt')
+    session.install('-e', '.')
+
+    session.run('sphinx-build', *args)
+
+
+@session
+def style(session: Session) -> None:
+    session.install('flake8')
+
+    session.run(
+        'flake8',
+        '--select=E501',
+        '--extend-exclude=.nox/',
+        '--max-line-length=79',
+    )


### PR DESCRIPTION
This PR comes without any previous discussion, so please feel free to just close this if it is undesired.

This adds a noxfile to automatically run the tests, coverage, and docs.  I've setup the Nox sessions to run essentially the same thing that is done in GitHub actions and the same way that read the docs should be building the docs.  Using Nox was helpful in my last PR.

If you're unfamiliar with Nox, it is similar to tox but uses a Python file to run the various sessions.  So with this, you can just run `nox` to run all tests on each Python version (use pyenv to manage them) and build the documentation locally.

https://nox.thea.codes/en/stable/index.html

I personally use pipx to install and manage nox.