### PR TITLE
Typo fix in link to nested example

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -11,6 +11,7 @@ next
   exception types.
 * Added `defopt.bind` to allow preprocessing arguments before performing the
   call.
+* Added the ability to use nested subcommands.
 
 6.1.0 (2021-02-25)
 ------------------

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -79,4 +79,12 @@ Docstring styles
     :undoc-members:
     :show-inheritance:
 
+Nested subcommands
+------------------
+
+.. automodule:: examples.nested
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. _examples: https://github.com/anntzer/defopt/tree/master/examples

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -79,6 +79,20 @@ Command line usage will use the new names ::
     positional arguments:
       {friendly_func,func2}
 
+Nested Subcommands
+------------------
+
+By using dictionaries, the subcommands can also be nested.
+
+.. code-block:: python
+
+    defopt.run({'func1': func1, 'sub': [func2, func3]})
+
+The nested subcommands are accessed e.g. by ``test.py sub func2``.  The
+subcommands can be nested to an arbitrary level by using nested dictionaries.
+
+A runnable example is available at `examples/nested.py`_.
+
 Standard types
 --------------
 
@@ -376,3 +390,4 @@ script importable independently of `defopt`.
 .. _examples/short.py: https://github.com/anntzer/defopt/blob/master/examples/short.py
 .. _examples/starargs.py: https://github.com/anntzer/defopt/blob/master/examples/starargs.py
 .. _examples/styles.py: https://github.com/anntzer/defopt/blob/master/examples/styles.py
+.. _examples/nested.py https://github.com/anntzer/defopt/blob/master/examples/nested.py

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -390,4 +390,4 @@ script importable independently of `defopt`.
 .. _examples/short.py: https://github.com/anntzer/defopt/blob/master/examples/short.py
 .. _examples/starargs.py: https://github.com/anntzer/defopt/blob/master/examples/starargs.py
 .. _examples/styles.py: https://github.com/anntzer/defopt/blob/master/examples/styles.py
-.. _examples/nested.py https://github.com/anntzer/defopt/blob/master/examples/nested.py
+.. _examples/nested.py: https://github.com/anntzer/defopt/blob/master/examples/nested.py

--- a/examples/nested.py
+++ b/examples/nested.py
@@ -1,0 +1,47 @@
+"""
+Example showing nested parsers in defopt.
+
+Code usage::
+
+    >>> main(1.5)
+    >>> sub1(2.0)
+    >>> sub2(2.5)
+
+Command line usage::
+
+    $ python nested.py main 1.5
+    $ python nested.py sub sub1 2.0
+    $ python nested.py sub sub2 2.5
+"""
+import defopt
+
+
+def main(number):
+    """
+    Example main function.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+def sub1(number):
+    """
+    Example sub command.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+def sub2(number):
+    """
+    Example sub command.
+
+    :param float number: Number to print
+    """
+    print(number)
+
+
+if __name__ == '__main__':
+    defopt.run({'main': main, 'sub': [sub1, sub2]})

--- a/lib/defopt.py
+++ b/lib/defopt.py
@@ -246,6 +246,36 @@ def run(funcs: Union[Callable, List[Callable], Dict[str, Callable]], *,
         sys.exit(e)
 
 
+def _recurse_functions(funcs, subparsers):
+    if not isinstance(funcs, collections.abc.Mapping):
+        # If this iterable is not a maping, then convert it to one using the
+        # function name itself as the key, but replacing _ with -.
+        try:
+            funcs = {func.__name__.replace('_', '-'): func for func in funcs}
+        except AttributeError as exc:
+            # Do not allow a mapping inside of a list
+            raise ValueError(
+                'Use dictionaries (mappings) for nesting; other iterables may '
+                'only contain functions (callables).'
+            ) from exc
+
+    for name, func in funcs.items():
+        if callable(func):
+            # If this item is callable, then add it to the current
+            # subparser using this name.
+            subparser = subparsers.add_parser(
+                name,
+                formatter_class=RawTextHelpFormatter,
+                help=_parse_docstring(inspect.getdoc(func)).first_line)
+            yield func, subparser
+        else:
+            # If this item is not callable, then add this name as a new
+            # subparser and recurse the the items.
+            nestedsubparser = subparsers.add_parser(name)
+            nestedsubparsers = nestedsubparser.add_subparsers()
+            yield from _recurse_functions(func, nestedsubparsers)
+
+
 def _create_parser(
         funcs, *,
         parsers={},
@@ -265,15 +295,7 @@ def _create_parser(
         version_sources.append(funcs)
     else:
         subparsers = parser.add_subparsers()
-        for func in funcs:
-            if isinstance(funcs, collections.abc.MutableMapping):
-                name, func = func, funcs[func]
-            else:
-                name = func.__name__.replace('_', '-')
-            subparser = subparsers.add_parser(
-                name,
-                formatter_class=RawTextHelpFormatter,
-                help=_parse_docstring(inspect.getdoc(func)).first_line)
+        for func, subparser in _recurse_functions(funcs, subparsers):
             _populate_parser(func, subparser, parsers, short, strict_kwonly,
                              show_defaults, show_types, no_negated_flags)
             version_sources.append(func)

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -434,14 +434,26 @@ class TestParsers(unittest.TestCase):
         def main(foo='default'):
             """:type foo: bool"""
             return foo
-        self.assertIs(defopt.run(main, strict_kwonly=False,
+        self.assertIs(defopt.run(main, cli_options='has_default',
                                  argv=[]), 'default')
-        self.assertIs(defopt.run(main, strict_kwonly=False,
+        self.assertIs(defopt.run(main, cli_options='has_default',
                                  argv=['--foo']), True)
-        self.assertIs(defopt.run(main, strict_kwonly=False,
+        self.assertIs(defopt.run(main, cli_options='has_default',
                                  argv=['--no-foo']), False)
-        self.assertIs(defopt.run(main, strict_kwonly=False,
+        self.assertIs(defopt.run(main, cli_options='has_default',
                                  argv=['--foo', '--no-foo']), False)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(defopt.run(main, strict_kwonly=False,
+                                     argv=[]), 'default')
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(defopt.run(main, strict_kwonly=False,
+                                     argv=['--foo']), True)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(defopt.run(main, strict_kwonly=False,
+                                     argv=['--no-foo']), False)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(defopt.run(main, strict_kwonly=False,
+                                     argv=['--foo', '--no-foo']), False)
 
     def test_bool_keyword_only(self):
         def main(*, foo):
@@ -449,6 +461,23 @@ class TestParsers(unittest.TestCase):
             return foo
         self.assertIs(defopt.run(main, argv=['--foo']), True)
         self.assertIs(defopt.run(main, argv=['--no-foo']), False)
+        with self.assertRaises(SystemExit):
+            defopt.run(main, argv=[])
+
+    def test_cli_options(self):
+        def main(foo):
+            """:type foo: bool"""
+            return foo
+        self.assertIs(
+            defopt.run(main, cli_options='all', argv=['--foo']), True)
+        self.assertIs(
+            defopt.run(main, cli_options='all', argv=['--no-foo']), False)
+        with self.assertRaises(SystemExit):
+            defopt.run(main, cli_options='all', argv=['1'])
+        with self.assertRaises(SystemExit):
+            defopt.run(main, argv=['--foo'])
+        with self.assertRaises(SystemExit):
+            defopt.run(main, argv=['--no-foo'])
         with self.assertRaises(SystemExit):
             defopt.run(main, argv=[])
 
@@ -473,7 +502,7 @@ class TestFlags(unittest.TestCase):
             """:type foo: int"""
             return foo
         self.assertEqual(
-            defopt.run(func, short={'foo': 'f'}, strict_kwonly=False,
+            defopt.run(func, short={'foo': 'f'}, cli_options='has_default',
                        argv=['-f', '2']),
             2)
 
@@ -1042,7 +1071,7 @@ class TestHelp(unittest.TestCase):
         self.assertLessEqual({*flags}, {'d', 't', 'n'})
         parser = defopt._create_parser(
             funcs, show_defaults='d' in flags, show_types='t' in flags,
-            no_negated_flags='n' in flags, strict_kwonly=False)
+            no_negated_flags='n' in flags, cli_options='has_default')
         return parser.format_help()
 
 

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -68,6 +68,133 @@ class TestDefopt(unittest.TestCase):
             defopt.run({"sub1": sub, "sub_2": sub_with_dash},
                        argv=['sub_2', '--baz', '1']), 1)
 
+    def test_nested_lists_invalid(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub1, [subsub1, subsub2]], argv=['sub1', '1.2'])
+
+    def test_nested_subcommands1(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-1', 'sub1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub-1": [sub1], "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands2(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub1": sub1, "sub-2": [subsub1, subsub2]},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands3(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-1', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-2', 'subsub1', '--baz', '1']), 1)
+        self.assertEqual(
+            defopt.run({"sub-1": sub1,
+                        "sub-2": {'subsub1': subsub1, 'subsub2': subsub2}},
+                       argv=['sub-2', 'subsub2', '1.5']), (1.5,))
+
+    def test_nested_subcommands_deep(self):
+        def sub(*bar):
+            """:type bar: float"""
+            return bar
+        self.assertEqual(
+            defopt.run({'a': {'b': {'c': {'d': {'e': sub}}}}},
+                       argv=['a', 'b', 'c', 'd', 'e', '1.2']), (1.2,))
+        self.assertEqual(
+            defopt.run({'a': {'b': {'c': {'d': {'e': [sub]}}}}},
+                       argv=['a', 'b', 'c', 'd', 'e', 'sub', '1.2']), (1.2,))
+
+    def test_nested_subcommands_mixed_invalid1(self):
+        def sub1(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub1(*, baz=None):
+            """:type baz: int"""
+            return baz
+        def subsub2(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub1', '1.2'])
+        with self.assertRaises(ValueError):
+                defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub2', 'subsub1', '--baz', '1'])
+        with self.assertRaises(ValueError):
+                defopt.run([sub1, {'sub2': [subsub1, subsub2]}],
+                        argv=['sub2', 'subsub2', '1.1'])
+
+    def test_nested_subcommands_mixed_invalid2(self):
+        def sub(*bar):
+            """:type bar: float"""
+            return bar
+        def subsub_with_dash(*, baz=None): 
+            """:type baz: int"""
+            return baz
+        def subsub(*foo):
+            """:type foo: float"""
+            return foo
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['sub', '1.2'])
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['subsub1', '--baz', '1'])
+        with self.assertRaises(ValueError):
+            defopt.run([sub, {'subsub1': subsub_with_dash, 'subsub2': subsub}],
+                       argv=['subsub2', '1.5'])
+
     def test_var_positional(self):
         for doc in [
                 ":type foo: int", r":type \*foo: int", ":param int foo: doc"]:


### PR DESCRIPTION
Quick typo fix in the nested example link.