### PR TITLE
Make Optional[bool] still act as a flag

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+next
+----
+* Fixed `typing.Optional[bool]` to still be treated as a flag.
+
 6.2.0 (2021-11-24)
 ------------------
 * Bumped docutils dependency to >=0.12, for setuptools compatibility.

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -243,6 +243,12 @@ order" rule given above, a parser for ``type(None)`` will always be tried
 first; this is so that e.g. ``Optional[str]`` can parse some user-chosen values
 as ``None`` and the others as ``str``.
 
+``typing.Optional[bool]`` is treated separately, as a special case, to still
+act as a boolean flag.  Defining a default value of ``None`` for the argument
+will result in receiving ``None`` if the option is not specified on the command
+line and either ``True`` or ``False`` if one of the two boolean flags are
+provided.
+
 Collection types are not supported in unions; e.g. ``Union[List[type1]]``
 is not supported (with the exception of ``Optional[List[type1]]``, which is
 *always* equivalent to ``List[type1]``).

--- a/lib/defopt.py
+++ b/lib/defopt.py
@@ -450,8 +450,9 @@ def _populate_parser(func, parser, parsers, short, cli_options,
         default = param.default if hasdefault else SUPPRESS
         required = not hasdefault and param.kind != param.VAR_POSITIONAL
         positional = name in positionals
-        if type_ == bool and not positional:
-            action = ('store_true' if no_negated_flags and default is False
+        if type_ in [bool, typing.Optional[bool]] and not positional:
+            action = ('store_true' if no_negated_flags and
+                      default in [False, None]
                       else _BooleanOptionalAction)  # --name/--no-name
             actions.append(_add_argument(
                 parser, name, short, action=action, default=default,


### PR DESCRIPTION
This is an initial implementation of the feature requested in #99.

I may not have thought through all of the potential cases here, so likely this testing would need to be expanded and the implementation thought through more closely.  But first I'd like to see if there is interest in it.

Using the code from the linked issue/feature request, it would now function as below (specifically note the line `skip = X`):

```console
$ python dummy.py
loops = 5
skip  = None
long loop iteration: 1
long loop iteration: 2
long loop iteration: 3
long loop iteration: 4
long loop iteration: 5
$ python dummy.py --skip
loops = 5
skip  = True
skipping loop printing
$ python dummy.py --no-skip
loops = 5
skip  = False
long loop iteration: 1
long loop iteration: 2
long loop iteration: 3
long loop iteration: 4
long loop iteration: 5

```

Closes #99