### PR TITLE
Fix exception for unparseable types

### DIFF
--- a/lib/defopt.py
+++ b/lib/defopt.py
@@ -1057,7 +1057,7 @@ def _is_constructible_from_str(type_, *, skip_first_arg=False):
     except ValueError:
         # Can be raised for classes, if the relevant info is in `__init__`.
         if not isinstance(type_, type):
-            raise
+            return False
     else:
         if sig.parameters[argname].annotation is str:
             return True

--- a/test_defopt.py
+++ b/test_defopt.py
@@ -598,7 +598,7 @@ class TestParsers(unittest.TestCase):
         def notok(foo):
             """:type foo: NotConstructibleFromStr"""
 
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, 'no parser.*NotConstructible'):
             defopt.run(notok, argv=["foo"])
 
 


### PR DESCRIPTION
Before:

```
ValueError: no type found for parameter s
```

After:

```
Exception: no parser found for type NotConstructibleFromStr
```